### PR TITLE
Modify return value of PBCF calculation

### DIFF
--- a/spaceeval/sports/basketball/models/BIMOS.py
+++ b/spaceeval/sports/basketball/models/BIMOS.py
@@ -304,11 +304,15 @@ def calculate_pbcf_pass(target_position, attacking_players, defending_players, b
             PBCFdef[i] += player.PPCF
         i += 1
 
+    # Handle very short paths to avoid tiny totals
     if i < 3:
-        return rel_att_ids, rel_def_ids, PBCFatt[i-1] / (PBCFatt[i-1] + PBCFdef[i-1]), PBCFdef[i-1] / (PBCFatt[i-1] + PBCFdef[i-1])
+        denom = max(PBCFatt[i-1] + PBCFdef[i-1], 1e-12)
+        return rel_att_ids, rel_def_ids, PBCFatt[i-1] / denom, PBCFdef[i-1] / denom
     else:
+        # If not fully converged but time horizon exhausted, return latest
         if PBCFatt[i-1] + PBCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size:
             return rel_att_ids, rel_def_ids, PBCFatt[i-1], PBCFdef[i-1]
+        # Else use the last stable step
         else:
             return  rel_att_ids, rel_def_ids, PBCFatt[i-2], PBCFdef[i-2]
 
@@ -356,13 +360,14 @@ def calculate_pbcf_dribble(target_position, attacking_players, defending_players
                 PBCFdef[i] += player.PPCF
             i += 1
 
-        if i < 3:
-            return rel_att_ids, rel_def_ids, PBCFatt[i-1] / (PBCFatt[i-1] + PBCFdef[i-1]), PBCFdef[i-1] / (PBCFatt[i-1] + PBCFdef[i-1])
+        # Handle very short paths to avoid tiny totals
+        # or If not fully converged but time horizon exhausted, return latest
+        if i < 3 or (PBCFatt[i-1] + PBCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size):
+            denom = max(PBCFatt[i-1] + PBCFdef[i-1], 1e-12)
+            return rel_att_ids, rel_def_ids, PBCFatt[i-1] / denom, PBCFdef[i-1] / denom
+        # Else use the last stable step
         else:
-            if PBCFatt[i-1] + PBCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size:
-                return rel_att_ids, rel_def_ids, PBCFatt[i-1], PBCFdef[i-1]
-            else:
-                return  rel_att_ids, rel_def_ids, PBCFatt[i-2], PBCFdef[i-2]
+            return rel_att_ids, rel_def_ids, PBCFatt[i-2], PBCFdef[i-2]
 
 
 

--- a/spaceeval/sports/basketball/models/BMOS.py
+++ b/spaceeval/sports/basketball/models/BMOS.py
@@ -296,11 +296,15 @@ def calculate_ppcf_pass(target_position, attacking_players, defending_players, b
             PPCFdef[i] += player.PPCF
         i += 1
 
+    # Handle very short paths to avoid tiny totals
     if i < 3:
-        return rel_att_id, rel_def_id, PPCFatt[i-1] / (PPCFatt[i-1] + PPCFdef[i-1]), PPCFdef[i-1] / (PPCFatt[i-1] + PPCFdef[i-1])
+        denom = max(PPCFatt[i-1] + PPCFdef[i-1], 1e-12)
+        return rel_att_id, rel_def_id, PPCFatt[i-1] / denom, PPCFdef[i-1] / denom
     else:
+        # If not fully converged but time horizon exhausted, return latest
         if PPCFatt[i-1] + PPCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size:
             return rel_att_id, rel_def_id, PPCFatt[i-1], PPCFdef[i-1]
+        # Else use the last stable step
         else:
             return  rel_att_id, rel_def_id, PPCFatt[i-2], PPCFdef[i-2]
 
@@ -343,11 +347,12 @@ def calculate_ppcf_dribble(target_position, attacking_players, defending_players
                 PPCFdef[i] += player.PPCF
             i += 1
 
-        if i < 3:
-            return rel_att_id, rel_def_id, PPCFatt[i-1] / (PPCFatt[i-1] + PPCFdef[i-1]), PPCFdef[i-1] / (PPCFatt[i-1] + PPCFdef[i-1])
+        # Handle very short paths to avoid tiny totals
+        # or If not fully converged but time horizon exhausted, return latest
+        if i < 3 or (PPCFatt[i-1] + PPCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size):
+            denom = max(PPCFatt[i-1] + PPCFdef[i-1], 1e-12)
+            return rel_att_id, rel_def_id, PPCFatt[i-1] / denom, PPCFdef[i-1] / denom
+        # Else use the last stable step
         else:
-            if PPCFatt[i-1] + PPCFdef[i-1] < 1 - params['model_converge_tol'] and i >= dt_array.size:
-                return rel_att_id, rel_def_id, PPCFatt[i-1], PPCFdef[i-1]
-            else:
-                return  rel_att_id, rel_def_id, PPCFatt[i-2], PPCFdef[i-2]
+            return  rel_att_id, rel_def_id, PPCFatt[i-2], PPCFdef[i-2]
 

--- a/spaceeval/sports/soccer/bimos/bimos_repo/cal_pbcf.py
+++ b/spaceeval/sports/soccer/bimos/bimos_repo/cal_pbcf.py
@@ -25,7 +25,7 @@ def _reset_player_contribs(players):
         # Laurie’s player class already exposes PPCF; we reuse it as our running contribution bucket.
         p.PPCF = 0.0
 
-def _integrate_pbcf(dt_array, attacking_players, defending_players, ball_start_pos, target_position, params, att_ids_filter=None, def_ids_filter=None):
+def _integrate_pbcf(dt_array, attacking_players, defending_players, ball_start_pos, target_position, params, deliver_type, att_ids_filter=None, def_ids_filter=None):
     """
     Core BIMOS/PBCF integrator (soccer-flavor):
     - For each time step t, evaluate the *moving* ball position r_mid(t)
@@ -86,9 +86,14 @@ def _integrate_pbcf(dt_array, attacking_players, defending_players, ball_start_p
         return P_att[i-1] / denom, P_def[i-1] / denom
     # If not fully converged but time horizon exhausted, return latest
     if (P_att[i-1] + P_def[i-1] < 1 - params['model_converge_tol']) and (i >= dt_array.size):
-        return P_att[i-1], P_def[i-1]
+        if deliver_type == 'pass':
+            return P_att[i-1], P_def[i-1]
+        else:  # dribble
+            denom = max(P_att[i-1] + P_def[i-1], 1e-12)
+            return P_att[i-1] / denom, P_def[i-1] / denom
     # Else use the last stable step
-    return P_att[i-2], P_def[i-2]
+    else:
+        return P_att[i-2], P_def[i-2]
 
 def calculate_pbcf_pass(target_position, attacking_players, defending_players, ball_start_pos, params):
     """
@@ -115,7 +120,7 @@ def calculate_pbcf_pass(target_position, attacking_players, defending_players, b
     def_ids_filter = None
 
     return _integrate_pbcf(dt_array, attacking_players, defending_players, ball_start_pos, target_position, params,
-                           att_ids_filter=att_ids_filter, def_ids_filter=def_ids_filter)
+                           deliver_type='pass', att_ids_filter=att_ids_filter, def_ids_filter=def_ids_filter)
 
 def calculate_pbcf_dribble(target_position, attacking_players, defending_players, ball_start_pos, params, possessor_id=None):
     """
@@ -144,7 +149,7 @@ def calculate_pbcf_dribble(target_position, attacking_players, defending_players
     def_ids_filter = None
 
     return _integrate_pbcf(dt_array, attacking_players, defending_players, ball_start_pos, target_position, params,
-                           att_ids_filter=att_ids_filter, def_ids_filter=def_ids_filter)
+                           deliver_type='dribble', att_ids_filter=att_ids_filter, def_ids_filter=def_ids_filter)
 
 def generate_pbcf_for_event(
     event_id,


### PR DESCRIPTION
Normalize the total probability to 1 for dribble actions. For passes, continue using raw PBCF values with out-of-bounds considered.